### PR TITLE
Load RootChain contract from genesis

### DIFF
--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -191,6 +191,8 @@ func initGenesis(ctx *cli.Context) error {
 	if len(genesis.ExtraData) != 20 {
 		utils.Fatalf("invalid rootchain contract address length")
 	}
+	rootChainContract := common.BytesToAddress(genesis.ExtraData)
+	log.Info("Using rootchain contract", "rootChainContract", rootChainContract)
 	// Open an initialise both full and light databases
 	stack := makeFullNode(ctx)
 	for _, name := range []string{"chaindata", "lightchaindata"} {
@@ -198,7 +200,6 @@ func initGenesis(ctx *cli.Context) error {
 		if err != nil {
 			utils.Fatalf("Failed to open database: %v", err)
 		}
-		rootChainContract := common.BytesToAddress(genesis.ExtraData)
 		_, hash, err := core.SetupGenesisBlock(chaindb, genesis, rootChainContract)
 		if err != nil {
 			utils.Fatalf("Failed to write genesis block: %v", err)

--- a/cmd/geth/genesis_test.go
+++ b/cmd/geth/genesis_test.go
@@ -23,43 +23,29 @@ import (
 	"testing"
 )
 
-var customGenesisTests = []struct {
+type CustomGenesisTest struct {
 	genesis string
 	query   string
 	result  string
-}{
-	// Plain genesis file without anything extra
-	{
-		genesis: `{
-			"alloc"      : {},
-			"coinbase"   : "0x0000000000000000000000000000000000000000",
-			"difficulty" : "0x20000",
-			"extraData"  : "",
-			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
-			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
-			"timestamp"  : "0x00"
-		}`,
-		query:  "pls.getBlock(0).nonce",
-		result: "0x0000000000000042",
-	},
+}
+
+var genesisTests = []CustomGenesisTest{
 	// Genesis file with an empty chain configuration (ensure missing fields work)
 	{
 		genesis: `{
 			"alloc"      : {},
 			"coinbase"   : "0x0000000000000000000000000000000000000000",
 			"difficulty" : "0x20000",
-			"extraData"  : "",
+			"extraData"  : "0x880ec53af800b5cd051531672ef4fc4de233bd5d",
 			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
+			"nonce"      : "0x07",
 			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"timestamp"  : "0x00",
 			"config"     : {}
 		}`,
-		query:  "pls.getBlock(0).nonce",
-		result: "0x0000000000000042",
+		query:  "eth.rootchain()",
+		result: "0x880ec53af800b5cd051531672ef4fc4de233bd5d",
 	},
 	// Genesis file with specific chain configurations
 	{
@@ -67,9 +53,9 @@ var customGenesisTests = []struct {
 			"alloc"      : {},
 			"coinbase"   : "0x0000000000000000000000000000000000000000",
 			"difficulty" : "0x20000",
-			"extraData"  : "",
+			"extraData"  : "0x880ec53af800b5cd051531672ef4fc4de233bd5d",
 			"gasLimit"   : "0x2fefd8",
-			"nonce"      : "0x0000000000000042",
+			"nonce"      : "0x07",
 			"mixhash"    : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"parentHash" : "0x0000000000000000000000000000000000000000000000000000000000000000",
 			"timestamp"  : "0x00",
@@ -79,15 +65,15 @@ var customGenesisTests = []struct {
 				"daoForkSupport" : true
 			}
 		}`,
-		query:  "pls.getBlock(0).nonce",
-		result: "0x0000000000000042",
+		query:  "eth.rootchain()",
+		result: "0x880ec53af800b5cd051531672ef4fc4de233bd5d",
 	},
 }
 
 // Tests that initializing Geth with a custom genesis block and chain definitions
 // work properly.
 func TestCustomGenesis(t *testing.T) {
-	for i, tt := range customGenesisTests {
+	for i, tt := range genesisTests {
 		// Create a temporary data directory to use and inspect later
 		datadir := tmpdir(t)
 		defer os.RemoveAll(datadir)

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1309,13 +1309,7 @@ func SetPlsConfig(ctx *cli.Context, stack *node.Node, cfg *pls.Config) {
 	}
 
 	cfg.RootChainURL = ctx.GlobalString(PlasmaRootChainUrlFlag.Name)
-
-	if !ctx.GlobalIsSet(PlasmaRootChainContractFlag.Name) {
-		Fatalf("RootChain contract address must be set, using --rootchain.contract")
-	}
 	cfg.RootChainContract = common.HexToAddress(ctx.GlobalString(PlasmaRootChainContractFlag.Name))
-
-	cfg.Genesis = core.DefaultGenesisBlock(cfg.RootChainContract)
 
 	// TODO(fjl): move trie cache generations into config
 	if gen := ctx.GlobalInt(TrieCacheGenFlag.Name); gen > 0 {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -162,10 +162,13 @@ func SetupGenesisBlockWithOverride(db ethdb.Database, genesis *Genesis, constant
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {
 		if genesis == nil {
-			log.Info("Writing default main-net genesis block")
+			log.Info("Writing default main-net genesis block", "rootChainContract", rootChainContract)
+			if (rootChainContract == common.Address{}) {
+				return nil, common.Hash{}, errors.New(fmt.Sprintf("RootChain contract address must be set, but %s", rootChainContract.Hex()))
+			}
 			genesis = DefaultGenesisBlock(rootChainContract)
 		} else {
-			log.Info("Writing custom genesis block")
+			log.Info("Writing custom genesis block", "rootChainContract", rootChainContract)
 		}
 		block, err := genesis.Commit(db)
 		return genesis.Config, block.Hash(), err

--- a/pls/backend.go
+++ b/pls/backend.go
@@ -125,6 +125,13 @@ func New(ctx *node.ServiceContext, config *Config) (*Plasma, error) {
 	if _, ok := genesisErr.(*params.ConfigCompatError); genesisErr != nil && !ok {
 		return nil, genesisErr
 	}
+	genesisBlock := rawdb.ReadBlock(chainDb, genesisHash, 0)
+	config.RootChainContract = common.BytesToAddress(genesisBlock.Extra())
+
+	if (config.RootChainContract == common.Address{}) {
+		return nil, errors.New("RootChain contract address must be set. Use rootchain.contract or initalize genesis with extra data")
+	}
+
 	log.Info("Initialised chain configuration", "config", chainConfig)
 
 	pls := &Plasma{


### PR DESCRIPTION
 - `geth init` requires JSON with extra data of 20 bytes.
 - `pls.Plasma`, `les.LightEthereum` read RootChain contract address from genesis block.