### PR TITLE
Create Deploy Flag, Exclude it from dev Flag

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -156,6 +156,7 @@ var (
 		utils.OperatorAddressFlag,
 		utils.OperatorKeyFlag,
 		utils.DeveloperKeyFlag,
+		utils.DeployFlag,
 		utils.RootChainUrlFlag,
 		utils.RootChainContractFlag,
 		utils.PlasmaMinGasPriceFlag,

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -93,6 +93,12 @@ var AppHelpFlagGroups = []flagGroup{
 		},
 	},
 	{
+		Name: "DEPLOY ROOTCHAIN CONTRACT",
+		Flags: []cli.Flag{
+			utils.DeployFlag,
+		},
+	},
+	{
 		Name: "ETHASH",
 		Flags: []cli.Flag{
 			utils.EthashCacheDirFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -157,6 +157,10 @@ var (
 		Name:  "override.constantinople",
 		Usage: "Manually specify constantinople fork-block, overriding the bundled setting",
 	}
+	DeployFlag = cli.BoolFlag{
+		Name: "deploy",
+		Usage: "Deploy RootChain Contract into rootchain",
+	}
 	DeveloperFlag = cli.BoolFlag{
 		Name:  "dev",
 		Usage: "Ephemeral proof-of-authority network with a pre-funded developer account, mining enabled",
@@ -1225,7 +1229,7 @@ func SetPlsConfig(ctx *cli.Context, stack *node.Node, cfg *pls.Config) {
 	// Avoid conflicting network flags
 	checkExclusive(ctx, DeveloperFlag, TestnetFlag, RinkebyFlag)
 	checkExclusive(ctx, LightServFlag, SyncModeFlag, "light")
-	checkExclusive(ctx, DeveloperFlag, RootChainContractFlag)
+	checkExclusive(ctx, DeployFlag, RootChainContractFlag)
 	checkExclusive(ctx, OperatorAddressFlag, OperatorKeyFlag)
 
 	ks := stack.AccountManager().Backends(keystore.KeyStoreType)[0].(*keystore.KeyStore)
@@ -1451,7 +1455,7 @@ func SetPlsConfig(ctx *cli.Context, stack *node.Node, cfg *pls.Config) {
 			cfg.NetworkId = 4
 		}
 		cfg.Genesis = core.DefaultRinkebyGenesisBlock()
-	case ctx.GlobalBool(DeveloperFlag.Name):
+	case ctx.GlobalBool(DeployFlag.Name):
 		if !ctx.GlobalIsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 1337
 		}
@@ -1687,6 +1691,8 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 		genesis = core.DefaultRinkebyGenesisBlock()
 	case ctx.GlobalBool(DeveloperFlag.Name):
 		Fatalf("Developer chains are ephemeral")
+	case ctx.GlobalBool(DeployFlag.Name):
+		Fatalf("Use DeployFlag chains are ephemeral")
 	}
 	return genesis
 }

--- a/run.pls.sh
+++ b/run.pls.sh
@@ -19,6 +19,7 @@ build/bin/geth \
   --datadir $DATADIR \
   --miner.etherbase 0x71562b71999873DB5b286dF957af199Ec94617F7 \
   --dev \
+  --deploy \
   --rpc \
   --rpcport 8547 \
   --dev.key $OPERATOR_KEY,$KEY1,$KEY2,$KEY3,$KEY4,$KEY5,$CHALLENGER_KEY \


### PR DESCRIPTION
There is need to exclude the feature of deploying rootcahin contract from Dev mode for p2p tset.

original:
Onther-Tech/go-ethereum: execute bash run.rootchain.sh
Onther-Tech/plasma-evm: execute bin/geth --dev console

now:
Onther-Tech/go-ethereum: execute bash run.rootchain.sh
Onther-Tech/plasma-evm: execute bin/geth --dev --deploy console

No longer deploy rootchain contract with only dev flag used.

It Replated #34