### PR TITLE
cmd/puppeth: use docker image name as parameters

### DIFF
--- a/cmd/puppeth/module_dashboard.go
+++ b/cmd/puppeth/module_dashboard.go
@@ -516,7 +516,7 @@ var dashboardMascot = []byte("\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x01s\x
 // dashboardDockerfile is the Dockerfile required to build an dashboard container
 // to aggregate various private network services under one easily accessible page.
 var dashboardDockerfile = `
-FROM mhart/alpine-node:latest
+FROM {{.Image}}
 
 RUN \
 	npm install connect serve-static && \
@@ -567,7 +567,7 @@ services:
 // deployDashboard deploys a new dashboard container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
-func deployDashboard(client *sshClient, network string, conf *config, config *dashboardInfos, nocache bool) ([]byte, error) {
+func deployDashboard(client *sshClient, network string, image string, conf *config, config *dashboardInfos, nocache bool) ([]byte, error) {
 	// Generate the content to upload to the server
 	workdir := fmt.Sprintf("%d", rand.Int63())
 	files := make(map[string][]byte)
@@ -575,6 +575,7 @@ func deployDashboard(client *sshClient, network string, conf *config, config *da
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(dashboardDockerfile)).Execute(dockerfile, map[string]interface{}{
 		"Network": network,
+		"Image":   image,
 	})
 	files[filepath.Join(workdir, "Dockerfile")] = dockerfile.Bytes()
 

--- a/cmd/puppeth/module_ethstats.go
+++ b/cmd/puppeth/module_ethstats.go
@@ -31,7 +31,7 @@ import (
 // ethstatsDockerfile is the Dockerfile required to build an ethstats backend
 // and associated monitoring site.
 var ethstatsDockerfile = `
-FROM puppeth/ethstats:latest
+FROM {{.Image}}
 
 RUN echo 'module.exports = {trusted: [{{.Trusted}}], banned: [{{.Banned}}], reserved: ["yournode"]};' > lib/utils/config.js
 `
@@ -62,7 +62,7 @@ services:
 // deployEthstats deploys a new ethstats container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
-func deployEthstats(client *sshClient, network string, port int, secret string, vhost string, trusted []string, banned []string, nocache bool) ([]byte, error) {
+func deployEthstats(client *sshClient, network string, image string, port int, secret string, vhost string, trusted []string, banned []string, nocache bool) ([]byte, error) {
 	// Generate the content to upload to the server
 	workdir := fmt.Sprintf("%d", rand.Int63())
 	files := make(map[string][]byte)
@@ -78,6 +78,7 @@ func deployEthstats(client *sshClient, network string, port int, secret string, 
 
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(ethstatsDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Image":   image,
 		"Trusted": strings.Join(trustedLabels, ", "),
 		"Banned":  strings.Join(bannedLabels, ", "),
 	})

--- a/cmd/puppeth/module_faucet.go
+++ b/cmd/puppeth/module_faucet.go
@@ -33,7 +33,7 @@ import (
 // faucetDockerfile is the Dockerfile required to build a faucet container to
 // grant crypto tokens based on GitHub authentications.
 var faucetDockerfile = `
-FROM onthertech/plasma-evm:alltools-latest
+FROM {{.Image}}
 
 ADD genesis.json /genesis.json
 ADD account.json /account.json
@@ -86,15 +86,16 @@ services:
 // deployFaucet deploys a new faucet container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
-func deployFaucet(client *sshClient, network string, bootnodes []string, config *faucetInfos, nocache bool) ([]byte, error) {
+func deployFaucet(client *sshClient, network string, image string, bootnodes []string, config *faucetInfos, nocache bool) ([]byte, error) {
 	// Generate the content to upload to the server
 	workdir := fmt.Sprintf("%d", rand.Int63())
 	files := make(map[string][]byte)
 
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(faucetDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Image":         image,
 		"NetworkID":     config.node.network,
-		"RootChainURL": config.node.rootchainURL,
+		"RootChainURL":  config.node.rootchainURL,
 		"Bootnodes":     strings.Join(bootnodes, ","),
 		"Ethstats":      config.node.ethstats,
 		"EthPort":       config.node.port,

--- a/cmd/puppeth/module_nginx.go
+++ b/cmd/puppeth/module_nginx.go
@@ -29,7 +29,7 @@ import (
 
 // nginxDockerfile is theis the Dockerfile required to build an nginx reverse-
 // proxy.
-var nginxDockerfile = `FROM jwilder/nginx-proxy`
+var nginxDockerfile = `FROM {{.Image}}`
 
 // nginxComposefile is the docker-compose.yml file required to deploy and maintain
 // an nginx reverse-proxy. The proxy is responsible for exposing one or more HTTP
@@ -56,7 +56,7 @@ services:
 // deployNginx deploys a new nginx reverse-proxy container to expose one or more
 // HTTP services running on a single host. If an instance with the specified
 // network name already exists there, it will be overwritten!
-func deployNginx(client *sshClient, network string, port int, nocache bool) ([]byte, error) {
+func deployNginx(client *sshClient, network string, image string, port int, nocache bool) ([]byte, error) {
 	log.Info("Deploying nginx reverse-proxy", "server", client.server, "port", port)
 
 	// Generate the content to upload to the server
@@ -64,7 +64,9 @@ func deployNginx(client *sshClient, network string, port int, nocache bool) ([]b
 	files := make(map[string][]byte)
 
 	dockerfile := new(bytes.Buffer)
-	template.Must(template.New("").Parse(nginxDockerfile)).Execute(dockerfile, nil)
+	template.Must(template.New("").Parse(nginxDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Image": image,
+	})
 	files[filepath.Join(workdir, "Dockerfile")] = dockerfile.Bytes()
 
 	composefile := new(bytes.Buffer)

--- a/cmd/puppeth/module_node.go
+++ b/cmd/puppeth/module_node.go
@@ -32,7 +32,7 @@ import (
 
 // nodeDockerfile is the Dockerfile required to run an Ethereum node.
 var nodeDockerfile = `
-FROM onthertech/plasma-evm:latest
+FROM {{.Image}}
 
 ADD genesis.json /genesis.json
 {{if .Operator}}
@@ -99,7 +99,7 @@ services:
 // deployNode deploys a new Ethereum node container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
-func deployNode(client *sshClient, network string, bootnodes []string, config *nodeInfos, nocache bool) ([]byte, error) {
+func deployNode(client *sshClient, network string, image string, bootnodes []string, config *nodeInfos, nocache bool) ([]byte, error) {
 	kind := "sealnode"
 	if config.operatorKeyJSON == "" && config.etherbase == "" {
 		kind = "bootnode"
@@ -156,6 +156,7 @@ func deployNode(client *sshClient, network string, bootnodes []string, config *n
 	unlock := strings.Join(accounts, ",")
 
 	template.Must(template.New("").Parse(nodeDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Image":        image,
 		"NetworkID":    config.network,
 		"RootChainURL": config.rootchainURL,
 		"Operator":     operator,

--- a/cmd/puppeth/module_wallet.go
+++ b/cmd/puppeth/module_wallet.go
@@ -30,7 +30,7 @@ import (
 
 // walletDockerfile is the Dockerfile required to run a web wallet.
 var walletDockerfile = `
-FROM puppeth/wallet:latest
+FROM {{.Image}}
 
 ADD genesis.json /genesis.json
 
@@ -81,13 +81,14 @@ services:
 // deployWallet deploys a new web wallet container to a remote machine via SSH,
 // docker and docker-compose. If an instance with the specified network name
 // already exists there, it will be overwritten!
-func deployWallet(client *sshClient, network string, bootnodes []string, config *walletInfos, nocache bool) ([]byte, error) {
+func deployWallet(client *sshClient, network string, image string, bootnodes []string, config *walletInfos, nocache bool) ([]byte, error) {
 	// Generate the content to upload to the server
 	workdir := fmt.Sprintf("%d", rand.Int63())
 	files := make(map[string][]byte)
 
 	dockerfile := new(bytes.Buffer)
 	template.Must(template.New("").Parse(walletDockerfile)).Execute(dockerfile, map[string]interface{}{
+		"Image":     image,
 		"Network":   strings.ToTitle(network),
 		"Denom":     strings.ToUpper(network),
 		"NetworkID": config.network,

--- a/cmd/puppeth/puppeth.go
+++ b/cmd/puppeth/puppeth.go
@@ -42,6 +42,41 @@ func main() {
 			Value: 3,
 			Usage: "log level to emit to the screen",
 		},
+		cli.StringFlag{
+			Name:  "images.ethstats",
+			Usage: "name of ethstats docker image",
+			Value: "puppeth/ethstats:latest",
+		},
+		cli.StringFlag{
+			Name:  "images.node",
+			Usage: "name of node docker image",
+			Value: "onthertech/plasma-evm:latest",
+		},
+		cli.StringFlag{
+			Name:  "images.explorer",
+			Usage: "name of explorer docker image",
+			Value: "onthertech/blockscout:latest",
+		},
+		cli.StringFlag{
+			Name:  "images.nginx",
+			Usage: "name of nginx docker image",
+			Value: "jwilder/nginx-proxy",
+		},
+		cli.StringFlag{
+			Name:  "images.wallet",
+			Usage: "name of wallet docker image",
+			Value: "puppeth/wallet:latest",
+		},
+		cli.StringFlag{
+			Name:  "images.faucet",
+			Usage: "name of faucet docker image",
+			Value: "onthertech/plasma-evm:alltools-latest",
+		},
+		cli.StringFlag{
+			Name:  "images.dashboard",
+			Usage: "name of dashboard docker image",
+			Value: "mhart/alpine-node:latest",
+		},
 	}
 	app.Before = func(c *cli.Context) error {
 		// Set up the logger to print everything and the random generator
@@ -57,9 +92,18 @@ func main() {
 // runWizard start the wizard and relinquish control to it.
 func runWizard(c *cli.Context) error {
 	network := c.String("network")
+	images := map[string]string{
+		"ethstats":  c.String("images.ethstats"),
+		"node":      c.String("images.node"),
+		"explorer":  c.String("images.explorer"),
+		"nginx":     c.String("images.nginx"),
+		"wallet":    c.String("images.wallet"),
+		"faucet":    c.String("images.faucet"),
+		"dashboard": c.String("images.dashboard"),
+	}
 	if strings.Contains(network, " ") || strings.Contains(network, "-") || strings.ToLower(network) != network {
 		log.Crit("No spaces, hyphens or capital letters allowed in network name")
 	}
-	makeWizard(c.String("network")).run()
+	makeWizard(c.String("network"), images).run()
 	return nil
 }

--- a/cmd/puppeth/wizard.go
+++ b/cmd/puppeth/wizard.go
@@ -73,6 +73,8 @@ type wizard struct {
 	network string // Network name to manage
 	conf    config // Configurations from previous runs
 
+	images map[string]string // Docker image names
+
 	servers  map[string]*sshClient // SSH connections to servers to administer
 	services map[string][]string   // Ethereum services known to be running on servers
 

--- a/cmd/puppeth/wizard_dashboard.go
+++ b/cmd/puppeth/wizard_dashboard.go
@@ -146,7 +146,7 @@ func (w *wizard) deployDashboard() {
 		fmt.Printf("Should the dashboard be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
-	if out, err := deployDashboard(client, w.network, &w.conf, infos, nocache); err != nil {
+	if out, err := deployDashboard(client, w.network, w.images["dashboard"], &w.conf, infos, nocache); err != nil {
 		log.Error("Failed to deploy dashboard container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_ethstats.go
+++ b/cmd/puppeth/wizard_ethstats.go
@@ -114,7 +114,7 @@ func (w *wizard) deployEthstats() {
 			trusted = append(trusted, client.address)
 		}
 	}
-	if out, err := deployEthstats(client, w.network, infos.port, infos.secret, infos.host, trusted, infos.banned, nocache); err != nil {
+	if out, err := deployEthstats(client, w.network, w.images["ethstats"], infos.port, infos.secret, infos.host, trusted, infos.banned, nocache); err != nil {
 		log.Error("Failed to deploy ethstats container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_explorer.go
+++ b/cmd/puppeth/wizard_explorer.go
@@ -119,7 +119,7 @@ func (w *wizard) deployExplorer() {
 		fmt.Printf("Should the explorer be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
-	if out, err := deployExplorer(client, w.network, w.conf.bootnodes, infos, nocache, w.conf.Genesis.Config.Clique != nil); err != nil {
+	if out, err := deployExplorer(client, w.network, w.images["explorer"], w.conf.bootnodes, infos, nocache, w.conf.Genesis.Config.Clique != nil); err != nil {
 		log.Error("Failed to deploy explorer container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_faucet.go
+++ b/cmd/puppeth/wizard_faucet.go
@@ -173,7 +173,7 @@ func (w *wizard) deployFaucet() {
 		fmt.Printf("Should the faucet be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
-	if out, err := deployFaucet(client, w.network, w.conf.bootnodes, infos, nocache); err != nil {
+	if out, err := deployFaucet(client, w.network, w.images["faucet"], w.conf.bootnodes, infos, nocache); err != nil {
 		log.Error("Failed to deploy faucet container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_genesis.go
+++ b/cmd/puppeth/wizard_genesis.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Onther-Tech/plasma-evm/params"
 )
 
+// TODO: deploy RootChain contract and make genesis
 // makeGenesis creates a new genesis struct based on some user input.
 func (w *wizard) makeGenesis() {
 	// Construct a default genesis block

--- a/cmd/puppeth/wizard_intro.go
+++ b/cmd/puppeth/wizard_intro.go
@@ -30,12 +30,13 @@ import (
 )
 
 // makeWizard creates and returns a new puppeth wizard.
-func makeWizard(network string) *wizard {
+func makeWizard(network string, images map[string]string) *wizard {
 	return &wizard{
 		network: network,
 		conf: config{
 			Servers: make(map[string][]byte),
 		},
+		images:   images,
 		servers:  make(map[string]*sshClient),
 		services: make(map[string][]string),
 		in:       bufio.NewReader(os.Stdin),

--- a/cmd/puppeth/wizard_nginx.go
+++ b/cmd/puppeth/wizard_nginx.go
@@ -48,7 +48,7 @@ func (w *wizard) ensureVirtualHost(client *sshClient, port int, def string) (str
 			fmt.Printf("Should the reverse-proxy be rebuilt from scratch (y/n)? (default = no)\n")
 			nocache = w.readDefaultYesNo(false)
 		}
-		if out, err := deployNginx(client, w.network, port, nocache); err != nil {
+		if out, err := deployNginx(client, w.network, w.images["nginx"], port, nocache); err != nil {
 			log.Error("Failed to deploy reverse-proxy", "err", err)
 			if len(out) > 0 {
 				fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_node.go
+++ b/cmd/puppeth/wizard_node.go
@@ -236,7 +236,7 @@ func (w *wizard) deployNode(boot bool) {
 		fmt.Printf("Should the node be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
-	if out, err := deployNode(client, w.network, w.conf.bootnodes, infos, nocache); err != nil {
+	if out, err := deployNode(client, w.network, w.images["node"], w.conf.bootnodes, infos, nocache); err != nil {
 		log.Error("Failed to deploy Ethereum node container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)

--- a/cmd/puppeth/wizard_wallet.go
+++ b/cmd/puppeth/wizard_wallet.go
@@ -98,7 +98,7 @@ func (w *wizard) deployWallet() {
 		fmt.Printf("Should the wallet be built from scratch (y/n)? (default = no)\n")
 		nocache = w.readDefaultYesNo(false)
 	}
-	if out, err := deployWallet(client, w.network, w.conf.bootnodes, infos, nocache); err != nil {
+	if out, err := deployWallet(client, w.network, w.images["wallet"], w.conf.bootnodes, infos, nocache); err != nil {
 		log.Error("Failed to deploy wallet container", "err", err)
 		if len(out) > 0 {
 			fmt.Printf("%s\n", out)


### PR DESCRIPTION
Below parameters are available for `puppeth` command.

```
   --images.ethstats value            name of ethstats docker image (default: "puppeth/ethstats:latest")
   --images.node value                name of node docker image (default: "onthertech/plasma-evm:latest")
   --images.explorer value            name of explorer docker image (default: "onthertech/blockscout:latest")
   --images.nginx value               name of nginx docker image (default: "jwilder/nginx-proxy")
   --images.wallet value              name of wallet docker image (default: "puppeth/wallet:latest")
   --images.faucet value              name of faucet docker image (default: "onthertech/plasma-evm:alltools-latest")
   --images.dashboard value           name of dashboard docker image (default: "mhart/alpine-node:latest")
```