### PR TITLE
Refactor staking command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Implementation of [Plasma EVM](https://hackmd.io/s/HyZ2ms8EX) You can check the 
   - [Test](#test)
   - [Command-line Options](#command-line-options)
   - [Additional Commands](#additional-commands)
-    - [Account](#account)
-    - [Deploy](#deploy)
+    - [account](#account)
+    - [deploy](#deploy)
+    - [manage-staking](#manage-staking)
     - [Staking](#staking)
 
 ## Development Status
@@ -170,31 +171,36 @@ PLASMA EVM - STAKING OPTIONS OPTIONS:
 ## Additional Commands
 For more information, run below command (and sub-command) with `--help` flag.
 
-### Account
+### account
 
 ```bash
 $ geth account importKey <privateKey>            # Import a private key from hex key into a new account
 $ geth account importHDwallet <mnemonic> <path>  # Import a mnemonic into a new account
 ```
 
-### Deploy
+### deploy
 ```bash
 $ geth deploy <genesisPath> <chainId> <withPETH> <NRELength>  # Deploy RootChain contract and make genesis file
+```
+
+### manage-staking
+
+```bash
+$ geth manage-staking deployManagers <withdrawalDelay> <seigPerBlock>  # Deploy staking manager contracts (except PowerTON)
+$ geth manage-staking deployPowerTON <roundDuration>                   # Deploy PowerTON contract
+$ geth manage-staking startPowerTON                                    # Start PowerTON first round
+$ geth manage-staking register                                         # Register RootChain contract
+$ geth manage-staking getManagers <path?>                              # Get staking managers addresses in database
+$ geth manage-staking setManagers <uri>                                # Set staking managers addresses in database
+$ geth manage-staking mintTON <to> <amount>                            # Mint TON to account (for dev)
 ```
 
 ### Staking
 
 ```bash
-$ geth staking deployManagers <withdrawalDelay> <seigPerBlock>  # Deploy staking manager contracts (except PowerTON)
-$ geth staking deployPowerTON <roundDuration>                   # Deploy PowerTON contract
-$ geth staking startPowerTON                                    # Start PowerTON first round
-$ geth staking getManagers <uri?>                               # Get staking managers addresses in database
-$ geth staking setManagers <uri>                                # Set staking managers addresses in database
-$ geth staking register                                         # Register RootChain contract
 $ geth staking balances <address>                               # Print balances of token and stake
-$ geth staking mintTON <to> <amount>                            # Mint TON to account (for dev)
-$ geth staking swapFromTON <tonAmount>                          # Swap TON with WTON
-$ geth staking swapToTON <wtonAmount>                           # Swap WTON with TON
+$ geth staking swapFromTON <tonAmount>                          # Swap TON to WTON
+$ geth staking swapToTON <wtonAmount>                           # Swap WTON to TON
 $ geth staking stake <amount>                                   # Stake WTON
 $ geth staking requestWithdrawal <amount?>                      # Make a withdrawal request
 $ geth staking processWithdrawal <numRequests?>                 # Process pending withdrawals

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -179,6 +179,7 @@ var (
 		utils.DeveloperKeyFlag,
 		utils.RootChainUrlFlag,
 		utils.RootChainContractFlag,
+		utils.RootChainGasPriceFlag,
 		utils.TxMinGasPriceFlag,
 		utils.TxMaxGasPriceFlag,
 		utils.TxResubmitFlag,
@@ -209,6 +210,16 @@ var (
 		utils.MetricsInfluxDBUsernameFlag,
 		utils.MetricsInfluxDBPasswordFlag,
 		utils.MetricsInfluxDBTagsFlag,
+	}
+
+	stakingFlags = []cli.Flag{
+		utils.RootChainTONFlag,
+		utils.RootChainWTONFlag,
+		utils.RootChainRegistryFlag,
+		utils.RootChainDepositManagerFlag,
+		utils.RootChainSeigManagerFlag,
+		utils.RootChainPowerTONFlag,
+		utils.RootChainSenderFlag,
 	}
 )
 
@@ -247,6 +258,7 @@ func init() {
 		// See retesteth.go
 		retestethCommand,
 		// See stakecmd.go
+		manageStakingCmd,
 		stakingCmd,
 	}
 	sort.Sort(cli.CommandsByName(app.Commands))
@@ -259,6 +271,7 @@ func init() {
 	app.Flags = append(app.Flags, staminaFlags...)
 	app.Flags = append(app.Flags, whisperFlags...)
 	app.Flags = append(app.Flags, metricsFlags...)
+	app.Flags = append(app.Flags, stakingFlags...)
 
 	app.Before = func(ctx *cli.Context) error {
 		return debug.Setup(ctx, "")

--- a/cmd/geth/usage.go
+++ b/cmd/geth/usage.go
@@ -303,6 +303,10 @@ var AppHelpFlagGroups = []flagGroup{
 	{
 		Name: "PLASMA EVM - STAKING OPTIONS",
 		Flags: []cli.Flag{
+			utils.UnlockedAccountFlag,
+			utils.PasswordFileFlag,
+			utils.RootChainSenderFlag,
+			utils.RootChainGasPriceFlag,
 			utils.RootChainTONFlag,
 			utils.RootChainWTONFlag,
 			utils.RootChainRegistryFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -761,7 +761,7 @@ var (
 	}
 	OperatorPasswordFileFlag = cli.StringFlag{
 		Name:  "operator.password",
-		Usage: "Plasma operator key as hex(for dev)",
+		Usage: "Operator password file to use for non-interactive password input",
 		Value: "",
 	}
 	OperatorMinEtherFlag = cli.StringFlag{
@@ -777,15 +777,26 @@ var (
 	}
 	ChallengerPasswordFileFlag = cli.StringFlag{
 		Name:  "challenger.password",
-		Usage: "Plasma operator key as hex(for dev)",
+		Usage: "Challenger password file to use for non-interactive password input",
 		Value: "",
 	}
 
-	// Rootchain Flags
+	// root chain client flags
 	RootChainUrlFlag = cli.StringFlag{
 		Name:  "rootchain.url",
 		Usage: "JSONRPC endpoint of rootchain provider. If URL is empty, ignore the provider.",
 	}
+	RootChainGasPriceFlag = BigFlag{
+		Name:  "rootchain.gasPrice",
+		Usage: "Transaction gas price to root chain in GWei",
+		Value: big.NewInt(10 * params.GWei),
+	}
+	RootChainSenderFlag = cli.StringFlag{
+		Name:  "rootchain.sender",
+		Usage: "Address of root chain transaction sender account. it MUST be unlocked by --unlock, --password flags (CAVEAT: To set plasma operator, use --operator flag)",
+	}
+
+	// Tokamak Network contracts flags
 	RootChainContractFlag = cli.StringFlag{
 		Name:  "rootchain.contract",
 		Usage: "Address of the RootChain contract",
@@ -813,11 +824,6 @@ var (
 	RootChainPowerTONFlag = cli.StringFlag{
 		Name:  "rootchain.powerton",
 		Usage: "Address of PowerTON contract",
-	}
-	RootChainGasPriceFlag = BigFlag{
-		Name:  "rootchain.gasPrice",
-		Usage: "Transaction gas price to root chain",
-		Value: big.NewInt(10 * params.GWei),
 	}
 
 	// Transaction Flags


### PR DESCRIPTION
 - add rootchain.sender flag. the sender account should be unlocked by --unlock, --password flags
 - some sub-commands of staking are moved to manage-staking command.
 - deploy command require --rootchain.sender flag instead of --operator flag
